### PR TITLE
feat: 支援 Gemini 3.1 Flash TTS 與多角色對話

### DIFF
--- a/src/gemini-tts-cli.cs
+++ b/src/gemini-tts-cli.cs
@@ -40,7 +40,8 @@ mergeOpt.AddAlias("-m");
 var noCacheOpt = new Option<bool>("--no-cache", () => false, "Disable cache feature and force regeneration");
 var sayItOpt = new Option<bool>("--sayit", () => false, "Play audio directly on Windows instead of writing output file");
 var singleOutputOpt = new Option<bool>("--single-output", () => false, "Output a single WAV from the entire --file content (disables batch mode)");
-var versionOpt = new Option<bool>("--version", () => false, "Show version and exit");
+var modelOpt = new Option<string>("--model", () => "gemini-2.5-flash-preview-tts", $"Gemini TTS model ID (default: gemini-2.5-flash-preview-tts)\nAvailable: gemini-2.5-flash-preview-tts, gemini-2.5-pro-preview-tts, gemini-3.1-flash-tts-preview");
+var versionOpt = new Option<bool>("--show-version", () => false, "Show version and exit");
 versionOpt.AddAlias("-v");
 
 var root = new RootCommand("Gemini TTS CLI - Convert text to speech using Google Gemini API");
@@ -54,6 +55,7 @@ root.AddOption(mergeOpt);
 root.AddOption(noCacheOpt);
 root.AddOption(sayItOpt);
 root.AddOption(singleOutputOpt);
+root.AddOption(modelOpt);
 root.AddOption(versionOpt);
 
 // Add validation to ensure either text or file is provided
@@ -180,6 +182,7 @@ root.SetHandler(async (InvocationContext context) =>
         var noCache = context.ParseResult.GetValueForOption(noCacheOpt);
         var sayIt = context.ParseResult.GetValueForOption(sayItOpt);
         var singleOutput = context.ParseResult.GetValueForOption(singleOutputOpt);
+        var model = context.ParseResult.GetValueForOption(modelOpt) ?? "gemini-2.5-flash-preview-tts";
         var showVersion = context.ParseResult.GetValueForOption(versionOpt);
 
         if (showVersion)
@@ -187,6 +190,9 @@ root.SetHandler(async (InvocationContext context) =>
             Console.WriteLine(GeminiTtsHelpers.GetVersionString());
             return;
         }
+
+        // Set the model ID from CLI option
+        GeminiTtsHelpers.ModelId = model;
 
         if (instructions.Contains(":"))
         {
@@ -347,7 +353,7 @@ public static class GeminiTtsHelpers
         Environment.Exit(1);
     }
 
-    public const string ModelId = "gemini-2.5-flash-preview-tts";
+    public static string ModelId = "gemini-2.5-flash-preview-tts";
     public const string ApiPath = "streamGenerateContent";
     public const int SampleHz = 24_000; // 24 kHz
     public const int Bits = 16;
@@ -482,39 +488,57 @@ public static class GeminiTtsHelpers
 
                 using var doc = JsonDocument.Parse(json);
 
-                var finishReason = doc.RootElement[0]
-                              .GetProperty("candidates")[0]
-                              .GetProperty("finishReason");
+                // Streaming response is a JSON array of chunks.
+                // Audio data may appear in earlier chunks while finishReason
+                // appears in a later chunk. Iterate all chunks to collect data.
+                var allBase64Parts = new List<string>();
+                string? lastFinishReason = null;
 
-                if (finishReason.GetString() != "STOP")
+                for (int i = 0; i < doc.RootElement.GetArrayLength(); i++)
                 {
+                    var element = doc.RootElement[i];
+                    if (element.TryGetProperty("candidates", out var candidates) && candidates.GetArrayLength() > 0)
+                    {
+                        var candidate = candidates[0];
+
+                        if (candidate.TryGetProperty("finishReason", out var fr))
+                        {
+                            lastFinishReason = fr.GetString();
+                        }
+
+                        if (candidate.TryGetProperty("content", out var content) &&
+                            content.TryGetProperty("parts", out var parts))
+                        {
+                            for (int j = 0; j < parts.GetArrayLength(); j++)
+                            {
+                                if (parts[j].TryGetProperty("inlineData", out var inlineData) &&
+                                    inlineData.TryGetProperty("data", out var dataVal))
+                                {
+                                    var b64 = dataVal.GetString();
+                                    if (!string.IsNullOrEmpty(b64))
+                                        allBase64Parts.Add(b64);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Accept audio data regardless of finishReason
+                if (allBase64Parts.Count > 0)
+                {
+                    return allBase64Parts.SelectMany(b64 => Convert.FromBase64String(b64)).ToArray();
+                }
+
+                // No audio data — retry
+                {
+                    var reason = lastFinishReason ?? "unknown";
                     var contextInfo = lineNumber.HasValue ? $" (Line {lineNumber}: {textPreview})" : "";
                     if (writeLogs)
-                        Console.WriteLine($"⚠️ Retry attempt {attempt + 1}{contextInfo}: The service declined to generate audio for this request.");
+                        Console.WriteLine($"⚠️ Retry attempt {attempt + 1}{contextInfo}: No audio data received (finishReason={reason}).");
                     attempt++;
                     await Task.Delay(1000);
                     continue;
                 }
-
-                var base64 = doc.RootElement[0]
-                              .GetProperty("candidates")[0]
-                              .GetProperty("content")
-                              .GetProperty("parts")[0]
-                              .GetProperty("inlineData")
-                              .GetProperty("data")
-                              .GetString();
-
-                if (string.IsNullOrWhiteSpace(base64))
-                {
-                    var contextInfo = lineNumber.HasValue ? $" (Line {lineNumber}: {textPreview})" : "";
-                    if (writeLogs)
-                        Console.WriteLine($"⚠️ Retry attempt {attempt + 1}{contextInfo}: Received empty audio data from the service.");
-                    attempt++;
-                    await Task.Delay(1000);
-                    continue;
-                }
-
-                return Convert.FromBase64String(base64);
             }
             catch (HttpRequestException ex)
             {

--- a/src/gemini-tts-cli.cs
+++ b/src/gemini-tts-cli.cs
@@ -40,7 +40,8 @@ mergeOpt.AddAlias("-m");
 var noCacheOpt = new Option<bool>("--no-cache", () => false, "Disable cache feature and force regeneration");
 var sayItOpt = new Option<bool>("--sayit", () => false, "Play audio directly on Windows instead of writing output file");
 var singleOutputOpt = new Option<bool>("--single-output", () => false, "Output a single WAV from the entire --file content (disables batch mode)");
-var modelOpt = new Option<string>("--model", () => "gemini-2.5-flash-preview-tts", $"Gemini TTS model ID (default: gemini-2.5-flash-preview-tts)\nAvailable: gemini-2.5-flash-preview-tts, gemini-2.5-pro-preview-tts, gemini-3.1-flash-tts-preview");
+var modelOpt = new Option<string>("--model", () => "gemini-2.5-flash-preview-tts", "Gemini TTS model ID");
+modelOpt.FromAmong("gemini-2.5-flash-preview-tts", "gemini-2.5-pro-preview-tts", "gemini-3.1-flash-tts-preview");
 var versionOpt = new Option<bool>("--show-version", () => false, "Show version and exit");
 versionOpt.AddAlias("-v");
 
@@ -182,7 +183,7 @@ root.SetHandler(async (InvocationContext context) =>
         var noCache = context.ParseResult.GetValueForOption(noCacheOpt);
         var sayIt = context.ParseResult.GetValueForOption(sayItOpt);
         var singleOutput = context.ParseResult.GetValueForOption(singleOutputOpt);
-        var model = context.ParseResult.GetValueForOption(modelOpt) ?? "gemini-2.5-flash-preview-tts";
+        var model = context.ParseResult.GetValueForOption(modelOpt)!;
         var showVersion = context.ParseResult.GetValueForOption(versionOpt);
 
         if (showVersion)
@@ -190,9 +191,6 @@ root.SetHandler(async (InvocationContext context) =>
             Console.WriteLine(GeminiTtsHelpers.GetVersionString());
             return;
         }
-
-        // Set the model ID from CLI option
-        GeminiTtsHelpers.ModelId = model;
 
         if (instructions.Contains(":"))
         {
@@ -248,7 +246,7 @@ root.SetHandler(async (InvocationContext context) =>
                     Console.WriteLine($"🎤 Using voice: {speaker1}");
                     Console.WriteLine($"🗂️ Cache mode: {(noCache ? "Disabled" : "Enabled")}");
 
-                    await GeminiTtsHelpers.GenerateSingleTts(instructions, speaker1, fullText, output, apiKey, noCache: noCache);
+                    await GeminiTtsHelpers.GenerateSingleTts(instructions, speaker1, fullText, output, apiKey, model, noCache: noCache);
                     Console.WriteLine($"✅ Generated {output}");
                 }
                 else
@@ -267,7 +265,7 @@ root.SetHandler(async (InvocationContext context) =>
                     Console.WriteLine($"🔗 Merge mode: {(merge ? "Yes" : "No")}");
                     Console.WriteLine($"🗂️ Cache mode: {(noCache ? "Disabled" : "Enabled")}");
                     
-                    await GeminiTtsHelpers.ProcessBatchTts(instructions, speaker1, textLines, output, concurrency, merge, apiKey, noCache);
+                    await GeminiTtsHelpers.ProcessBatchTts(instructions, speaker1, textLines, output, concurrency, merge, apiKey, model, noCache);
                 }
             }
             catch (Exception ex)
@@ -305,14 +303,14 @@ root.SetHandler(async (InvocationContext context) =>
             {
                 if (sayIt)
                 {
-                    using var wavStream = await GeminiTtsHelpers.GenerateSingleTtsWavStream(instructions, speaker1, text!, apiKey, noCache: noCache);
+                    using var wavStream = await GeminiTtsHelpers.GenerateSingleTtsWavStream(instructions, speaker1, text!, apiKey, model, noCache: noCache);
                     Console.WriteLine("🔊 Playing audio...");
                     GeminiTtsHelpers.PlayWavStream(wavStream);
                     Console.WriteLine("✅ Playback complete");
                 }
                 else
                 {
-                    await GeminiTtsHelpers.GenerateSingleTts(instructions, speaker1, text!, output, apiKey, noCache: noCache);
+                    await GeminiTtsHelpers.GenerateSingleTts(instructions, speaker1, text!, output, apiKey, model, noCache: noCache);
                     if (!isStdout)
                     {
                         Console.WriteLine($"✅ Generated {output}");
@@ -353,7 +351,7 @@ public static class GeminiTtsHelpers
         Environment.Exit(1);
     }
 
-    public static string ModelId = "gemini-2.5-flash-preview-tts";
+    public const string DefaultModelId = "gemini-2.5-flash-preview-tts";
     public const string ApiPath = "streamGenerateContent";
     public const int SampleHz = 24_000; // 24 kHz
     public const int Bits = 16;
@@ -433,7 +431,7 @@ public static class GeminiTtsHelpers
             .ToArray();
     }
 
-    private static async Task<byte[]> GeneratePcmBytes(string instructions, string speaker1, string text, string apiKey, int? lineNumber = null, string? textPreview = null, bool writeLogs = true)
+    private static async Task<byte[]> GeneratePcmBytes(string instructions, string speaker1, string text, string apiKey, string modelId, int? lineNumber = null, string? textPreview = null, bool writeLogs = true)
     {
         // Compose the instruction for Gemini TTS
         string prompt = instructions + ": " + text;
@@ -476,7 +474,7 @@ public static class GeminiTtsHelpers
             {
                 // Create a new request for each attempt
                 var req = new HttpRequestMessage(HttpMethod.Post,
-                    $"v1beta/models/{ModelId}:{ApiPath}?key={apiKey}")
+                    $"v1beta/models/{modelId}:{ApiPath}?key={apiKey}")
                 {
                     Content = new StringContent(payloadJson, Encoding.UTF8, "application/json")
                 };
@@ -526,7 +524,12 @@ public static class GeminiTtsHelpers
                 // Accept audio data regardless of finishReason
                 if (allBase64Parts.Count > 0)
                 {
-                    return allBase64Parts.SelectMany(b64 => Convert.FromBase64String(b64)).ToArray();
+                    var allBytes = new List<byte>();
+                    foreach (var b64 in allBase64Parts)
+                    {
+                        allBytes.AddRange(Convert.FromBase64String(b64));
+                    }
+                    return allBytes.ToArray();
                 }
 
                 // No audio data — retry
@@ -572,7 +575,7 @@ public static class GeminiTtsHelpers
         throw new Exception($"Failed to generate audio after {maxRetries} attempts");
     }
 
-    public static async Task<string> GenerateSingleTts(string instructions, string speaker1, string text, string output, string apiKey, int? lineNumber = null, string? textPreview = null, bool noCache = false)
+    public static async Task<string> GenerateSingleTts(string instructions, string speaker1, string text, string output, string apiKey, string modelId, int? lineNumber = null, string? textPreview = null, bool noCache = false)
 {
     bool isStdout = output == "-";
     bool writeLogs = !isStdout;
@@ -613,7 +616,7 @@ public static class GeminiTtsHelpers
         }
     }
 
-    var pcmBytes = await GeneratePcmBytes(instructions, speaker1, text, apiKey, lineNumber, textPreview, writeLogs);
+    var pcmBytes = await GeneratePcmBytes(instructions, speaker1, text, apiKey, modelId, lineNumber, textPreview, writeLogs);
 
     // ---------- Convert RAW to WAV ----------
     using var ms = new MemoryStream(pcmBytes);
@@ -666,7 +669,7 @@ public static class GeminiTtsHelpers
     }
 }
 
-    public static async Task<MemoryStream> GenerateSingleTtsWavStream(string instructions, string speaker1, string text, string apiKey, bool noCache = false)
+    public static async Task<MemoryStream> GenerateSingleTtsWavStream(string instructions, string speaker1, string text, string apiKey, string modelId, bool noCache = false)
     {
         bool writeLogs = true;
 
@@ -695,7 +698,7 @@ public static class GeminiTtsHelpers
             }
         }
 
-        var pcmBytes = await GeneratePcmBytes(instructions, speaker1, text, apiKey, writeLogs: writeLogs);
+        var pcmBytes = await GeneratePcmBytes(instructions, speaker1, text, apiKey, modelId, writeLogs: writeLogs);
 
         using var ms = new MemoryStream(pcmBytes);
         using var raw = new RawSourceWaveStream(ms, new WaveFormat(SampleHz, Bits, Channels));
@@ -760,7 +763,7 @@ public static class GeminiTtsHelpers
     return Path.Combine(directory, numberedName);
 }
 
-    public static async Task ProcessBatchTts(string instructions, string speaker1, string[] textLines, string baseOutput, int concurrency, bool merge, string apiKey, bool noCache = false)
+    public static async Task ProcessBatchTts(string instructions, string speaker1, string[] textLines, string baseOutput, int concurrency, bool merge, string apiKey, string modelId, bool noCache = false)
     {
         Console.WriteLine($"📚 Processing {textLines.Length} lines with concurrency level {concurrency}");
         
@@ -786,7 +789,7 @@ public static class GeminiTtsHelpers
                 {
                     Console.WriteLine($"🎵 Processing line {index}: {text.Substring(0, Math.Min(50, text.Length))}...");
                     var textPreview = text.Substring(0, Math.Min(30, text.Length)) + (text.Length > 30 ? "..." : "");
-                    return await GenerateSingleTts(instructions, speaker1, text, outputFile, apiKey, index, textPreview, noCache);
+                    return await GenerateSingleTts(instructions, speaker1, text, outputFile, apiKey, modelId, index, textPreview, noCache);
                 }
                 finally
                 {

--- a/src/gemini-tts-cli.cs
+++ b/src/gemini-tts-cli.cs
@@ -40,8 +40,9 @@ mergeOpt.AddAlias("-m");
 var noCacheOpt = new Option<bool>("--no-cache", () => false, "Disable cache feature and force regeneration");
 var sayItOpt = new Option<bool>("--sayit", () => false, "Play audio directly on Windows instead of writing output file");
 var singleOutputOpt = new Option<bool>("--single-output", () => false, "Output a single WAV from the entire --file content (disables batch mode)");
-var modelOpt = new Option<string>("--model", () => "gemini-2.5-flash-preview-tts", "Gemini TTS model ID");
-modelOpt.FromAmong("gemini-2.5-flash-preview-tts", "gemini-2.5-pro-preview-tts", "gemini-3.1-flash-tts-preview");
+var speakersOpt = new Option<string?>("--speakers", "Multi-speaker mode: map character names to voices\nFormat: \"Name1:Voice1,Name2:Voice2\"\nExample: --speakers \"Alice:Kore,Bob:Puck\"");
+var modelOpt = new Option<string>("--model", () => GeminiTtsHelpers.DefaultModelId, "Gemini TTS model ID");
+modelOpt.FromAmong("gemini-3.1-flash-tts-preview", "gemini-2.5-flash-preview-tts", "gemini-2.5-pro-preview-tts");
 var versionOpt = new Option<bool>("--show-version", () => false, "Show version and exit");
 versionOpt.AddAlias("-v");
 
@@ -56,6 +57,7 @@ root.AddOption(mergeOpt);
 root.AddOption(noCacheOpt);
 root.AddOption(sayItOpt);
 root.AddOption(singleOutputOpt);
+root.AddOption(speakersOpt);
 root.AddOption(modelOpt);
 root.AddOption(versionOpt);
 
@@ -183,6 +185,7 @@ root.SetHandler(async (InvocationContext context) =>
         var noCache = context.ParseResult.GetValueForOption(noCacheOpt);
         var sayIt = context.ParseResult.GetValueForOption(sayItOpt);
         var singleOutput = context.ParseResult.GetValueForOption(singleOutputOpt);
+        var speakers = context.ParseResult.GetValueForOption(speakersOpt);
         var model = context.ParseResult.GetValueForOption(modelOpt)!;
         var showVersion = context.ParseResult.GetValueForOption(versionOpt);
 
@@ -190,6 +193,18 @@ root.SetHandler(async (InvocationContext context) =>
         {
             Console.WriteLine(GeminiTtsHelpers.GetVersionString());
             return;
+        }
+
+        // Parse multi-speaker config
+        Dictionary<string, string>? speakersConfig = null;
+        if (!string.IsNullOrEmpty(speakers))
+        {
+            speakersConfig = GeminiTtsHelpers.ParseSpeakers(speakers, allowedVoices);
+            if (speakersConfig == null || speakersConfig.Count == 0)
+            {
+                GeminiTtsHelpers.ExitWithError("❌ Error: Invalid --speakers format. Use \"Name1:Voice1,Name2:Voice2\" (at least 2 speakers required).");
+            }
+            Console.WriteLine($"🎭 Multi-speaker mode: {string.Join(", ", speakersConfig!.Select(kv => $"{kv.Key}={kv.Value}"))}");
         }
 
         if (instructions.Contains(":"))
@@ -246,7 +261,7 @@ root.SetHandler(async (InvocationContext context) =>
                     Console.WriteLine($"🎤 Using voice: {speaker1}");
                     Console.WriteLine($"🗂️ Cache mode: {(noCache ? "Disabled" : "Enabled")}");
 
-                    await GeminiTtsHelpers.GenerateSingleTts(instructions, speaker1, fullText, output, apiKey, model, noCache: noCache);
+                    await GeminiTtsHelpers.GenerateSingleTts(instructions, speaker1, fullText, output, apiKey, model, speakersConfig, noCache: noCache);
                     Console.WriteLine($"✅ Generated {output}");
                 }
                 else
@@ -265,7 +280,7 @@ root.SetHandler(async (InvocationContext context) =>
                     Console.WriteLine($"🔗 Merge mode: {(merge ? "Yes" : "No")}");
                     Console.WriteLine($"🗂️ Cache mode: {(noCache ? "Disabled" : "Enabled")}");
                     
-                    await GeminiTtsHelpers.ProcessBatchTts(instructions, speaker1, textLines, output, concurrency, merge, apiKey, model, noCache);
+                    await GeminiTtsHelpers.ProcessBatchTts(instructions, speaker1, textLines, output, concurrency, merge, apiKey, model, speakersConfig, noCache);
                 }
             }
             catch (Exception ex)
@@ -303,7 +318,7 @@ root.SetHandler(async (InvocationContext context) =>
             {
                 if (sayIt)
                 {
-                    using var wavStream = await GeminiTtsHelpers.GenerateSingleTtsWavStream(instructions, speaker1, text!, apiKey, model, noCache: noCache);
+                    using var wavStream = await GeminiTtsHelpers.GenerateSingleTtsWavStream(instructions, speaker1, text!, apiKey, model, speakersConfig, noCache: noCache);
                     Console.WriteLine("🔊 Playing audio...");
                     GeminiTtsHelpers.PlayWavStream(wavStream);
                     Console.WriteLine("✅ Playback complete");
@@ -351,7 +366,7 @@ public static class GeminiTtsHelpers
         Environment.Exit(1);
     }
 
-    public const string DefaultModelId = "gemini-2.5-flash-preview-tts";
+    public const string DefaultModelId = "gemini-3.1-flash-tts-preview";
     public const string ApiPath = "streamGenerateContent";
     public const int SampleHz = 24_000; // 24 kHz
     public const int Bits = 16;
@@ -420,6 +435,30 @@ public static class GeminiTtsHelpers
 
     public static bool IsFileReference(string? text) => !string.IsNullOrEmpty(text) && (text.StartsWith("@") || text.StartsWith("\"@"));
 
+    public static Dictionary<string, string>? ParseSpeakers(string input, HashSet<string> allowedVoices)
+    {
+        var result = new Dictionary<string, string>();
+        var pairs = input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        foreach (var pair in pairs)
+        {
+            var parts = pair.Split(':', 2, StringSplitOptions.TrimEntries);
+            if (parts.Length != 2 || string.IsNullOrEmpty(parts[0]) || string.IsNullOrEmpty(parts[1]))
+            {
+                Console.Error.WriteLine($"⚠️ Invalid speaker mapping: \"{pair}\". Expected format: Name:Voice");
+                return null;
+            }
+            var name = parts[0];
+            var voice = parts[1];
+            if (!allowedVoices.Contains(voice))
+            {
+                Console.Error.WriteLine($"⚠️ Unknown voice: \"{voice}\". Use 'list-voices' to see available voices.");
+                return null;
+            }
+            result[name] = voice;
+        }
+        return result.Count >= 2 ? result : null;
+    }
+
     public static string[] ReadAndFilterFileLines(string filePath)
     {
         var lines = File.ReadAllLines(filePath);
@@ -431,35 +470,75 @@ public static class GeminiTtsHelpers
             .ToArray();
     }
 
-    private static async Task<byte[]> GeneratePcmBytes(string instructions, string speaker1, string text, string apiKey, string modelId, int? lineNumber = null, string? textPreview = null, bool writeLogs = true)
+    private static async Task<byte[]> GeneratePcmBytes(string instructions, string speaker1, string text, string apiKey, string modelId, Dictionary<string, string>? speakersConfig = null, int? lineNumber = null, string? textPreview = null, bool writeLogs = true)
     {
         // Compose the instruction for Gemini TTS
         string prompt = instructions + ": " + text;
 
         // ---------- Compose JSON ----------
-        var payload = new
+        object payload;
+
+        if (speakersConfig != null && speakersConfig.Count >= 2)
         {
-            contents = new[]
+            var speakerVoiceConfigs = speakersConfig.Select(kv => new
             {
-                new
+                speaker = kv.Key,
+                voice_config = new
                 {
-                    role  = "user",
-                    parts = new[] { new { text = prompt } }
+                    prebuilt_voice_config = new { voice_name = Capitalize(kv.Value) }
                 }
-            },
-            generationConfig = new
+            }).ToArray();
+
+            payload = new
             {
-                responseModalities = new[] { "audio" },
-                temperature = 1,
-                speech_config = new
+                contents = new[]
                 {
-                    voice_config = new
+                    new
                     {
-                        prebuilt_voice_config = new { voice_name = Capitalize(speaker1) }
+                        role  = "user",
+                        parts = new[] { new { text = prompt } }
+                    }
+                },
+                generationConfig = new
+                {
+                    responseModalities = new[] { "audio" },
+                    temperature = 1,
+                    speech_config = new
+                    {
+                        multi_speaker_voice_config = new
+                        {
+                            speaker_voice_configs = speakerVoiceConfigs
+                        }
                     }
                 }
-            }
-        };
+            };
+        }
+        else
+        {
+            payload = new
+            {
+                contents = new[]
+                {
+                    new
+                    {
+                        role  = "user",
+                        parts = new[] { new { text = prompt } }
+                    }
+                },
+                generationConfig = new
+                {
+                    responseModalities = new[] { "audio" },
+                    temperature = 1,
+                    speech_config = new
+                    {
+                        voice_config = new
+                        {
+                            prebuilt_voice_config = new { voice_name = Capitalize(speaker1) }
+                        }
+                    }
+                }
+            };
+        }
 
         var payloadJson = JsonSerializer.Serialize(payload);
 
@@ -575,7 +654,7 @@ public static class GeminiTtsHelpers
         throw new Exception($"Failed to generate audio after {maxRetries} attempts");
     }
 
-    public static async Task<string> GenerateSingleTts(string instructions, string speaker1, string text, string output, string apiKey, string modelId, int? lineNumber = null, string? textPreview = null, bool noCache = false)
+    public static async Task<string> GenerateSingleTts(string instructions, string speaker1, string text, string output, string apiKey, string modelId, Dictionary<string, string>? speakersConfig = null, int? lineNumber = null, string? textPreview = null, bool noCache = false)
 {
     bool isStdout = output == "-";
     bool writeLogs = !isStdout;
@@ -616,7 +695,7 @@ public static class GeminiTtsHelpers
         }
     }
 
-    var pcmBytes = await GeneratePcmBytes(instructions, speaker1, text, apiKey, modelId, lineNumber, textPreview, writeLogs);
+    var pcmBytes = await GeneratePcmBytes(instructions, speaker1, text, apiKey, modelId, speakersConfig, lineNumber, textPreview, writeLogs);
 
     // ---------- Convert RAW to WAV ----------
     using var ms = new MemoryStream(pcmBytes);
@@ -669,7 +748,7 @@ public static class GeminiTtsHelpers
     }
 }
 
-    public static async Task<MemoryStream> GenerateSingleTtsWavStream(string instructions, string speaker1, string text, string apiKey, string modelId, bool noCache = false)
+    public static async Task<MemoryStream> GenerateSingleTtsWavStream(string instructions, string speaker1, string text, string apiKey, string modelId, Dictionary<string, string>? speakersConfig = null, bool noCache = false)
     {
         bool writeLogs = true;
 
@@ -698,7 +777,7 @@ public static class GeminiTtsHelpers
             }
         }
 
-        var pcmBytes = await GeneratePcmBytes(instructions, speaker1, text, apiKey, modelId, writeLogs: writeLogs);
+        var pcmBytes = await GeneratePcmBytes(instructions, speaker1, text, apiKey, modelId, speakersConfig, writeLogs: writeLogs);
 
         using var ms = new MemoryStream(pcmBytes);
         using var raw = new RawSourceWaveStream(ms, new WaveFormat(SampleHz, Bits, Channels));
@@ -763,7 +842,7 @@ public static class GeminiTtsHelpers
     return Path.Combine(directory, numberedName);
 }
 
-    public static async Task ProcessBatchTts(string instructions, string speaker1, string[] textLines, string baseOutput, int concurrency, bool merge, string apiKey, string modelId, bool noCache = false)
+    public static async Task ProcessBatchTts(string instructions, string speaker1, string[] textLines, string baseOutput, int concurrency, bool merge, string apiKey, string modelId, Dictionary<string, string>? speakersConfig = null, bool noCache = false)
     {
         Console.WriteLine($"📚 Processing {textLines.Length} lines with concurrency level {concurrency}");
         
@@ -789,7 +868,7 @@ public static class GeminiTtsHelpers
                 {
                     Console.WriteLine($"🎵 Processing line {index}: {text.Substring(0, Math.Min(50, text.Length))}...");
                     var textPreview = text.Substring(0, Math.Min(30, text.Length)) + (text.Length > 30 ? "..." : "");
-                    return await GenerateSingleTts(instructions, speaker1, text, outputFile, apiKey, modelId, index, textPreview, noCache);
+                    return await GenerateSingleTts(instructions, speaker1, text, outputFile, apiKey, modelId, speakersConfig, index, textPreview, noCache);
                 }
                 finally
                 {

--- a/tests/IntegrationTests.cs
+++ b/tests/IntegrationTests.cs
@@ -43,7 +43,7 @@ public class IntegrationTests
         try
         {
             // Act
-            var result = await GeminiTtsHelpers.GenerateSingleTts(instructions, speaker1, text, output, apiKey);
+            var result = await GeminiTtsHelpers.GenerateSingleTts(instructions, speaker1, text, output, apiKey, GeminiTtsHelpers.DefaultModelId);
 
             // Assert
             Assert.Equal(output, result);

--- a/tests/TtsApiTests.cs
+++ b/tests/TtsApiTests.cs
@@ -24,15 +24,17 @@ public class TtsApiTests
             
             // Verify parameters
             var parameters = method.GetParameters();
-            Assert.Equal(8, parameters.Length);
-            Assert.Equal(typeof(string), parameters[0].ParameterType); // instructions
-            Assert.Equal(typeof(string), parameters[1].ParameterType); // speaker1
-            Assert.Equal(typeof(string), parameters[2].ParameterType); // text
-            Assert.Equal(typeof(string), parameters[3].ParameterType); // output
-            Assert.Equal(typeof(string), parameters[4].ParameterType); // apiKey
-            Assert.Equal(typeof(int?), parameters[5].ParameterType);   // lineNumber
-            Assert.Equal(typeof(string), parameters[6].ParameterType); // textPreview
-            Assert.Equal(typeof(bool), parameters[7].ParameterType);   // noCache
+            Assert.Equal(10, parameters.Length);
+            Assert.Equal(typeof(string), parameters[0].ParameterType);                     // instructions
+            Assert.Equal(typeof(string), parameters[1].ParameterType);                     // speaker1
+            Assert.Equal(typeof(string), parameters[2].ParameterType);                     // text
+            Assert.Equal(typeof(string), parameters[3].ParameterType);                     // output
+            Assert.Equal(typeof(string), parameters[4].ParameterType);                     // apiKey
+            Assert.Equal(typeof(string), parameters[5].ParameterType);                     // modelId
+            Assert.Equal(typeof(Dictionary<string, string>), parameters[6].ParameterType); // speakersConfig
+            Assert.Equal(typeof(int?), parameters[7].ParameterType);                       // lineNumber
+            Assert.Equal(typeof(string), parameters[8].ParameterType);                     // textPreview
+            Assert.Equal(typeof(bool), parameters[9].ParameterType);                       // noCache
         }
         finally
         {
@@ -84,15 +86,17 @@ public class TtsApiTests
         Assert.Equal(typeof(Task), method.ReturnType);
         
         var parameters = method.GetParameters();
-        Assert.Equal(8, parameters.Length);
-        Assert.Equal(typeof(string), parameters[0].ParameterType);   // instructions
-        Assert.Equal(typeof(string), parameters[1].ParameterType);   // speaker1
-        Assert.Equal(typeof(string[]), parameters[2].ParameterType); // textLines
-        Assert.Equal(typeof(string), parameters[3].ParameterType);   // baseOutput
-        Assert.Equal(typeof(int), parameters[4].ParameterType);      // concurrency
-        Assert.Equal(typeof(bool), parameters[5].ParameterType);     // merge
-        Assert.Equal(typeof(string), parameters[6].ParameterType);   // apiKey
-        Assert.Equal(typeof(bool), parameters[7].ParameterType);     // noCache
+        Assert.Equal(10, parameters.Length);
+        Assert.Equal(typeof(string), parameters[0].ParameterType);                     // instructions
+        Assert.Equal(typeof(string), parameters[1].ParameterType);                     // speaker1
+        Assert.Equal(typeof(string[]), parameters[2].ParameterType);                   // textLines
+        Assert.Equal(typeof(string), parameters[3].ParameterType);                     // baseOutput
+        Assert.Equal(typeof(int), parameters[4].ParameterType);                        // concurrency
+        Assert.Equal(typeof(bool), parameters[5].ParameterType);                       // merge
+        Assert.Equal(typeof(string), parameters[6].ParameterType);                     // apiKey
+        Assert.Equal(typeof(string), parameters[7].ParameterType);                     // modelId
+        Assert.Equal(typeof(Dictionary<string, string>), parameters[8].ParameterType); // speakersConfig
+        Assert.Equal(typeof(bool), parameters[9].ParameterType);                       // noCache
     }
 }
 
@@ -102,7 +106,7 @@ public class ConstantsTests
     public void Constants_ShouldHaveExpectedValues()
     {
         // Assert
-        Assert.Equal("gemini-2.5-flash-preview-tts", GeminiTtsHelpers.ModelId);
+        Assert.Equal("gemini-3.1-flash-tts-preview", GeminiTtsHelpers.DefaultModelId);
         Assert.Equal("streamGenerateContent", GeminiTtsHelpers.ApiPath);
         Assert.Equal(24_000, GeminiTtsHelpers.SampleHz);
         Assert.Equal(16, GeminiTtsHelpers.Bits);


### PR DESCRIPTION
## 摘要

支援 Google 最新發布的 **Gemini 3.1 Flash TTS** 模型，並新增 `--speakers` 多角色對話功能。預設模型為 `gemini-3.1-flash-tts-preview`。

關閉 #31（多角色功能已整併至本 PR）

## 解決的問題

### 1. Gemini 3.1 Flash TTS 相容性（關鍵 bug）

原解析邏輯只讀取 `RootElement[0]`，但 Gemini 3.1 的 streaming response 會把音訊資料放在較早的 chunk、`finishReason` 放在較後的 chunk，造成 `KeyNotFoundException`，使得 3.1 模型完全無法使用。

### 2. `--version` 參數衝突

原版的 `--version` 自訂選項與 System.CommandLine 內建的 `--version` handler 衝突，啟動時拋出 `ArgumentException: An item with the same key has already been added`。

## 新增功能

### `--model`（多模型切換）
- 預設：`gemini-3.1-flash-tts-preview`
- 可選：`gemini-2.5-flash-preview-tts`、`gemini-2.5-pro-preview-tts`
- 使用 `FromAmong()` 自動驗證並顯示於 `--help`

```bash
# 預設使用 3.1（無須指定）
gemini-tts -t "你好" -s Kore -o hello.wav

# 切換舊版
gemini-tts -t "你好" -s Kore -o hello.wav --model gemini-2.5-flash-preview-tts
```

### `--speakers`（多角色對話）
- 格式：`"Name1:Voice1,Name2:Voice2"`（至少 2 個角色）
- 對應 Gemini 的 `multi_speaker_voice_config` API
- 角色名稱需與文稿中的名稱完全一致

```bash
gemini-tts -f dialogue.txt --single-output \
    --speakers "Alice:Kore,Bob:Puck" \
    -o dialogue.wav
```

**輸入文稿格式：**
```
TTS the following conversation between Alice and Bob:

Alice: Hey, how are you doing today?
Bob: I'm doing great, thanks!
```

## 其他調整

- **修正 streaming response 解析**：遍歷所有 chunk、使用 `TryGetProperty` 避免 `KeyNotFoundException`、收集並串接所有 chunk 的音訊資料
- **重命名 `--version`**：改為 `--show-version`（`-v` alias 保留）避免與 System.CommandLine 衝突
- **`ModelId` 從 `const` 改為方法參數**：避免全域可變狀態，提升可測試性
- **音訊資料串接優化**：改用 `List<byte>` + `AddRange` 取代 `SelectMany().ToArray()`

## 方法簽章變更

```csharp
// 原簽章
GenerateSingleTts(string instructions, string speaker1, string text,
    string output, string apiKey, ...);  // 8 參數

// 新簽章
GenerateSingleTts(string instructions, string speaker1, string text,
    string output, string apiKey,
    string modelId,                                  // 新增
    Dictionary<string, string>? speakersConfig,      // 新增
    ...);  // 10 參數
```

`ProcessBatchTts` 與 `GenerateSingleTtsWavStream` 同樣新增兩個參數。

## 測試計畫

- [x] `dotnet build` 0 warnings / 0 errors
- [x] `dotnet test` 54 tests 全部通過
- [x] `--help` 顯示新選項與 3.1 為預設模型
- [x] 測試檔案同步更新（`TtsApiTests.cs` 的參數斷言、`IntegrationTests.cs` 的 `modelId` 引數、`ConstantsTests` 的 `DefaultModelId` 斷言）


🤖 Generated with [Claude Code](https://claude.com/claude-code)